### PR TITLE
Increase upload file limits

### DIFF
--- a/demo/frontend/src/common/components/gallery/useUploadVideo.ts
+++ b/demo/frontend/src/common/components/gallery/useUploadVideo.ts
@@ -25,8 +25,8 @@ const ACCEPT_VIDEOS = {
   'video/quicktime': ['.mov'],
 };
 
-// 70 MB default max video upload size
-const MAX_FILE_SIZE_IN_MB = 70;
+// Default max video upload size in MB
+const MAX_FILE_SIZE_IN_MB = 2048;
 const MAX_VIDEO_UPLOAD_SIZE = MAX_FILE_SIZE_IN_MB * 1024 ** 2;
 
 type Props = {

--- a/demo/frontend/src/common/loading/UploadLoadingScreen.tsx
+++ b/demo/frontend/src/common/loading/UploadLoadingScreen.tsx
@@ -28,7 +28,7 @@ export default function UploadLoadingScreen() {
     return (
       <LoadingStateScreen
         title="Uh oh, we cannot process this video"
-        description="Please upload another video, and make sure that the video’s file size is less than 70Mb. ">
+        description="Please upload another video, and make sure that the video’s file size is less than 2048MB. ">
         <div className="max-w-[250px] w-full mx-auto">
           <ChangeVideoModal
             videoGalleryModalTrigger={UploadLoadingScreenChangeVideoTrigger}

--- a/demo/frontend/src/demo/DemoConfig.tsx
+++ b/demo/frontend/src/demo/DemoConfig.tsx
@@ -41,4 +41,5 @@ export const DEFAULT_EFFECT_LAYERS: EffectLayers = {
   highlight: 'Overlay',
 };
 
-export const MAX_UPLOAD_FILE_SIZE = '70MB';
+// Maximum allowed upload size for user provided videos
+export const MAX_UPLOAD_FILE_SIZE = '2048MB';


### PR DESCRIPTION
## Summary
- bump frontend upload limit to 2GB
- update upload helper logic
- reference new limit in error message

## Testing
- `ufmt format demo/frontend/src/demo/DemoConfig.tsx demo/frontend/src/common/components/gallery/useUploadVideo.ts demo/frontend/src/common/loading/UploadLoadingScreen.tsx` *(fails: Syntax Error)*

------
https://chatgpt.com/codex/tasks/task_e_68448a7c27a48321bf04236c1e679db7