### PR TITLE
Update video upload limit

### DIFF
--- a/demo/backend/server/app_conf.py
+++ b/demo/backend/server/app_conf.py
@@ -22,9 +22,12 @@ FFMPEG_NUM_THREADS = int(os.getenv("FFMPEG_NUM_THREADS", "1"))
 # Path for all data used in API
 DATA_PATH = Path(os.getenv("DATA_PATH", "/data"))
 
-# Max duration an uploaded video can have in seconds. The default is 10
-# seconds.
-MAX_UPLOAD_VIDEO_DURATION = float(os.environ.get("MAX_UPLOAD_VIDEO_DURATION", "10"))
+# Max duration an uploaded video can have in seconds. The default is two
+# hours (7200 seconds) but can be overridden via the MAX_UPLOAD_VIDEO_DURATION
+# environment variable.
+MAX_UPLOAD_VIDEO_DURATION = float(
+    os.environ.get("MAX_UPLOAD_VIDEO_DURATION", "7200")
+)
 
 # If set, it will define which video is returned by the default video query for
 # desktop

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,6 +33,7 @@ services:
       - VIDEO_ENCODE_MAX_WIDTH=1280
       - VIDEO_ENCODE_MAX_HEIGHT=720
       - VIDEO_ENCODE_VERBOSE=False
+      - MAX_UPLOAD_VIDEO_DURATION=7200
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
## Summary
- increase MAX_UPLOAD_VIDEO_DURATION default to two hours
- expose MAX_UPLOAD_VIDEO_DURATION in docker-compose backend service

## Testing
- `python -m py_compile demo/backend/server/app_conf.py`

------
https://chatgpt.com/codex/tasks/task_e_68448a822cf0832194e5441023bc42f1