### PR TITLE
Add background propagation API with progress

### DIFF
--- a/demo/backend/server/app_conf.py
+++ b/demo/backend/server/app_conf.py
@@ -48,8 +48,14 @@ POSTERS_PREFIX = "posters"
 # Path where all posters are stored
 POSTERS_PATH = DATA_PATH / POSTERS_PREFIX
 
+# Directory used to store processed video segments that can be downloaded by the
+# client. Each background propagation run will write its results in this folder.
+SEGMENTS_PREFIX = "segments"
+SEGMENTS_PATH = DATA_PATH / SEGMENTS_PREFIX
+
 # Make sure any of those paths exist
 os.makedirs(DATA_PATH, exist_ok=True)
 os.makedirs(GALLERY_PATH, exist_ok=True)
 os.makedirs(UPLOADS_PATH, exist_ok=True)
 os.makedirs(POSTERS_PATH, exist_ok=True)
+os.makedirs(SEGMENTS_PATH, exist_ok=True)

--- a/demo/backend/server/data/data_types.py
+++ b/demo/backend/server/data/data_types.py
@@ -152,3 +152,21 @@ class SessionExpiration:
     expiration_time: int
     max_expiration_time: int
     ttl: int
+
+
+@strawberry.input
+class StartBackgroundPropagationInput:
+    session_id: str
+    start_frame_index: int = 0
+
+
+@strawberry.type
+class BackgroundPropagation:
+    success: bool
+
+
+@strawberry.type
+class PropagationStatus:
+    progress: float
+    status: str
+    download_url: Optional[str]

--- a/demo/frontend/src/common/components/options/DownloadOption.tsx
+++ b/demo/frontend/src/common/components/options/DownloadOption.tsx
@@ -15,18 +15,18 @@
  */
 import {Package} from '@carbon/icons-react';
 import OptionButton from './OptionButton';
-import useDownloadVideo from './useDownloadVideo';
+import useBackendPropagation from './useBackendPropagation';
 
 export default function DownloadOption() {
-  const {download, state} = useDownloadVideo();
+  const {download, state} = useBackendPropagation();
 
   return (
     <OptionButton
       title="Download"
       Icon={Package}
       loadingProps={{
-        loading: state === 'started' || state === 'encoding',
-        label: 'Downloading...',
+        loading: state === 'running',
+        label: 'Processing...',
       }}
       onClick={download}
     />

--- a/demo/frontend/src/common/components/options/useBackendPropagation.ts
+++ b/demo/frontend/src/common/components/options/useBackendPropagation.ts
@@ -1,0 +1,54 @@
+import {getFileName} from './ShareUtils';
+import {useAtomValue} from 'jotai';
+import {sessionAtom} from '@/demo/atoms';
+import useSettingsContext from '@/settings/useSettingsContext';
+import {useState} from 'react';
+
+export default function useBackendPropagation() {
+  const {settings} = useSettingsContext();
+  const session = useAtomValue(sessionAtom);
+  const [progress, setProgress] = useState(0);
+  const [state, setState] = useState<'default' | 'running' | 'completed'>('default');
+
+  async function download() {
+    if (!session) {
+      return;
+    }
+    setState('running');
+    await fetch(`${settings.inferenceAPIEndpoint}/background_propagate`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({session_id: session.id, start_frame_index: 0}),
+    });
+
+    const interval = window.setInterval(async () => {
+      const res = await fetch(
+        `${settings.inferenceAPIEndpoint}/propagate_status/${session.id}`,
+      );
+      const data = await res.json();
+      setProgress(data.progress);
+      if (data.status === 'completed') {
+        window.clearInterval(interval);
+        const fileRes = await fetch(
+          `${settings.inferenceAPIEndpoint}/download_segments/${session.id}`,
+        );
+        const blob = await fileRes.blob();
+        saveVideo(blob, getFileName());
+        setState('completed');
+      }
+    }, 1000);
+  }
+
+  function saveVideo(blob: Blob, fileName: string) {
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    document.body.appendChild(a);
+    a.setAttribute('href', url);
+    a.setAttribute('download', fileName);
+    a.setAttribute('target', '_self');
+    a.click();
+    window.URL.revokeObjectURL(url);
+  }
+
+  return {download, progress, state};
+}


### PR DESCRIPTION
## Summary
- support storing processed segments under `SEGMENTS_PATH`
- add async propagation helpers in predictor
- expose REST and GraphQL endpoints for background propagation
- update demo frontend to poll backend progress and enable downloads

## Testing
- `python -m py_compile demo/backend/server/app.py demo/backend/server/inference/predictor.py demo/backend/server/app_conf.py demo/backend/server/data/data_types.py demo/backend/server/data/schema.py`
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68448a9259a8832194f6d33ed2c6b26f