### PR TITLE
Object clip download support

### DIFF
--- a/demo/backend/server/data/data_types.py
+++ b/demo/backend/server/data/data_types.py
@@ -60,6 +60,14 @@ class RLEMaskForObject:
 
 
 @strawberry.type
+class ObjectClip:
+    """Video clip information for an object."""
+
+    object_id: int
+    url: str
+
+
+@strawberry.type
 class RLEMaskListOnFrame:
     """Type for a list of object-associated RLE masks on a specific video frame."""
 

--- a/demo/backend/server/data/schema.py
+++ b/demo/backend/server/data/schema.py
@@ -18,6 +18,7 @@ from app_conf import (
     MAX_UPLOAD_VIDEO_DURATION,
     UPLOADS_PATH,
     UPLOADS_PREFIX,
+    API_URL,
 )
 from data.data_types import (
     AddPointsInput,
@@ -32,6 +33,7 @@ from data.data_types import (
     RLEMask,
     RLEMaskForObject,
     RLEMaskListOnFrame,
+    ObjectClip,
     StartSession,
     StartSessionInput,
     Video,
@@ -86,6 +88,12 @@ class Query:
         """
         all_videos = get_videos()
         return all_videos.values()
+
+    @strawberry.field
+    def object_clip_urls(self, info: strawberry.Info, session_id: str) -> List[ObjectClip]:
+        inference_api: InferenceAPI = info.context["inference_api"]
+        mapping = inference_api.get_object_clip_urls(session_id)
+        return [ObjectClip(object_id=k, url=f"{API_URL}/{v}") for k, v in mapping.items()]
 
 
 @strawberry.type

--- a/demo/frontend/src/common/components/options/ObjectClipDownloadOption.tsx
+++ b/demo/frontend/src/common/components/options/ObjectClipDownloadOption.tsx
@@ -1,0 +1,60 @@
+import OptionButton from './OptionButton';
+import useVideo from '../video/editor/useVideo';
+import {sessionAtom} from '@/demo/atoms';
+import {Download} from '@carbon/icons-react';
+import {useAtomValue} from 'jotai';
+import {useEffect, useState} from 'react';
+import {VIDEO_API_ENDPOINT} from '@/demo/DemoConfig';
+
+export default function ObjectClipDownloadOption() {
+  const video = useVideo();
+  const session = useAtomValue(sessionAtom);
+  const [urls, setUrls] = useState<string[] | null>(null);
+
+  useEffect(() => {
+    function onCompleted() {
+      if (session == null) {
+        return;
+      }
+      fetch(`${VIDEO_API_ENDPOINT}/graphql`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+          query: `query ObjectClipUrls($sessionId: String!) { objectClipUrls(sessionId: $sessionId) { objectId url } }`,
+          variables: {sessionId: session.id},
+        }),
+      })
+        .then(r => r.json())
+        .then(res => {
+          if (res.data && res.data.objectClipUrls) {
+            setUrls(res.data.objectClipUrls.map((o: any) => o.url));
+          }
+        })
+        .catch(() => {});
+    }
+
+    video?.addEventListener('streamingCompleted', onCompleted);
+    return () => {
+      video?.removeEventListener('streamingCompleted', onCompleted);
+    };
+  }, [video, session]);
+
+  function handleClick() {
+    if (!urls) {
+      return;
+    }
+    urls.forEach(url => {
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = '';
+      a.target = '_blank';
+      a.click();
+    });
+  }
+
+  if (!urls) {
+    return null;
+  }
+
+  return <OptionButton title="Download Clips" Icon={Download} onClick={handleClick} />;
+}

--- a/demo/frontend/src/common/components/options/ShareSection.tsx
+++ b/demo/frontend/src/common/components/options/ShareSection.tsx
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 import DownloadOption from './DownloadOption';
+import ObjectClipDownloadOption from './ObjectClipDownloadOption';
 
 export default function ShareSection() {
   return (
     <div className="p-5 md:p-8">
       <DownloadOption />
+      <ObjectClipDownloadOption />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- track frame ranges for each object in async propagation
- cut out clips with ffmpeg and store in uploads
- expose `objectClipUrls` GraphQL field
- download clips in the frontend when propagation finishes

## Testing
- `python -m py_compile demo/backend/server/data/data_types.py demo/backend/server/data/schema.py demo/backend/server/inference/predictor.py`
- `npx tsc -p demo/frontend/tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68448a9654a48321add8a9c59a4f039a